### PR TITLE
結合テストのCREATE・PATCH・DELETEについて実装

### DIFF
--- a/src/main/java/com/example/homework10/controller/MusicController.java
+++ b/src/main/java/com/example/homework10/controller/MusicController.java
@@ -75,7 +75,7 @@ public class MusicController {
     @PatchMapping("/music/{id}")
     public ResponseEntity<Map<String, String>> update(@PathVariable int id, @Validated @RequestBody MusicUpdateForm musicUpdateForm) throws Exception {
         Music updateMusic = musicUpdateForm.convertToMusic(id, musicUpdateForm);
-        musicService.updateMusic(id, updateMusic);
+        musicService.updateMusic(updateMusic.getId(), updateMusic.getTitle(), updateMusic.getSinger());
         return ResponseEntity.ok(Map.of("message", "music successfully updated"));
     }
 

--- a/src/main/java/com/example/homework10/mapper/MusicMapper.java
+++ b/src/main/java/com/example/homework10/mapper/MusicMapper.java
@@ -4,6 +4,7 @@ import com.example.homework10.entity.Music;
 import org.apache.ibatis.annotations.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 
@@ -12,7 +13,7 @@ public interface MusicMapper {
     List<Music> findAll();
 
     @Select("SELECT * FROM music WHERE id = #{id}")
-    Music findById(int id);
+    Optional<Music> findById(int id);
 
     @Select("SELECT * FROM music WHERE title = #{title}")
     Music findByTitle(String title);
@@ -22,8 +23,9 @@ public interface MusicMapper {
     void createMusic(Music createMusic);
 
     @Update("UPDATE music SET title = #{title}, singer = #{singer} WHERE id = #{id}")
-    void updateMusic(Music updateMusic);
+    void updateMusic(int id, String title, String singer);
 
     @Delete("DELETE FROM music WHERE id = #{id}")
     void deleteMusic(int id);
+
 }

--- a/src/main/java/com/example/homework10/service/MusicService.java
+++ b/src/main/java/com/example/homework10/service/MusicService.java
@@ -1,6 +1,7 @@
 package com.example.homework10.service;
 
 import com.example.homework10.entity.Music;
+import com.example.homework10.exception.NotMusicFoundException;
 
 import java.util.List;
 
@@ -11,8 +12,7 @@ public interface MusicService {
 
     Music createMusic(String title, String singer) throws Exception;
 
-
-    Music updateMusic(int id, Music musicUpdateForm) throws Exception;
+    void updateMusic(int id, String title, String singer) throws NotMusicFoundException;
 
     void deleteMusic(int id);
 

--- a/src/main/java/com/example/homework10/service/MusicServiceImpl.java
+++ b/src/main/java/com/example/homework10/service/MusicServiceImpl.java
@@ -45,13 +45,14 @@ public class MusicServiceImpl implements MusicService {
 
     @Override
     public Music updateMusic(int id, Music updateMusic) throws NotMusicFoundException {
-        if (musicMapper.findById(id) == null) {
-            throw new NotMusicFoundException("Music not found");
-        } else {
-            updateMusic.setId(id);
+        Optional<Music> music = Optional.ofNullable(musicMapper.findById(id));
+        if (music.isPresent()) {
             musicMapper.updateMusic(updateMusic);
             return updateMusic;
+        } else {
+            throw new NotMusicFoundException("Music not found");
         }
+
     }
 
     @Override

--- a/src/main/java/com/example/homework10/service/MusicServiceImpl.java
+++ b/src/main/java/com/example/homework10/service/MusicServiceImpl.java
@@ -44,9 +44,14 @@ public class MusicServiceImpl implements MusicService {
 
 
     @Override
-    public Music updateMusic(int id, Music updateMusic) throws Exception {
-        musicMapper.updateMusic(updateMusic);
-        return updateMusic;
+    public Music updateMusic(int id, Music updateMusic) throws NotMusicFoundException {
+        if (musicMapper.findById(id) == null) {
+            throw new NotMusicFoundException("Music not found");
+        } else {
+            updateMusic.setId(id);
+            musicMapper.updateMusic(updateMusic);
+            return updateMusic;
+        }
     }
 
     @Override

--- a/src/main/java/com/example/homework10/service/MusicServiceImpl.java
+++ b/src/main/java/com/example/homework10/service/MusicServiceImpl.java
@@ -8,7 +8,6 @@ import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class MusicServiceImpl implements MusicService {
@@ -25,8 +24,7 @@ public class MusicServiceImpl implements MusicService {
 
     @Override
     public Music findById(int id) {
-        Optional<Music> music = Optional.ofNullable(musicMapper.findById(id));
-        return music.orElseThrow(() -> new NotMusicFoundException("Music not found"));
+        return musicMapper.findById(id).orElseThrow(() -> new NotMusicFoundException("Music not found"));
     }
 
     @Override
@@ -44,14 +42,9 @@ public class MusicServiceImpl implements MusicService {
 
 
     @Override
-    public Music updateMusic(int id, Music updateMusic) throws NotMusicFoundException {
-        Optional<Music> music = Optional.ofNullable(musicMapper.findById(id));
-        if (music.isPresent()) {
-            musicMapper.updateMusic(updateMusic);
-            return updateMusic;
-        } else {
-            throw new NotMusicFoundException("Music not found");
-        }
+    public void updateMusic(int id, String title, String singer) throws NotMusicFoundException {
+        musicMapper.findById(id).orElseThrow(() -> new NotMusicFoundException("Music not found"));
+        musicMapper.updateMusic(id, title, singer);
 
     }
 

--- a/src/test/java/com/example/homework10/integrationtest/MusicApiIntegrationTest.java
+++ b/src/test/java/com/example/homework10/integrationtest/MusicApiIntegrationTest.java
@@ -3,6 +3,7 @@ package com.example.homework10.integrationtest;
 
 import com.example.homework10.entity.Music;
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -18,6 +19,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -85,6 +89,7 @@ class MusicApiIntegrationTest {
 
     @Test
     @DataSet(value = "datasets/music.yml")
+    @ExpectedDataSet(value = "datasets/expected_music.yml", ignoreCols = "id")
     @Transactional
     void ミュージックが作成されること() throws Exception {
         Music music = new Music(39, "ハルカ", "YOASOBI");
@@ -98,14 +103,14 @@ class MusicApiIntegrationTest {
                                         }
                                         """))
                         .andExpect(MockMvcResultMatchers.status().isCreated())
-                        .andExpect(MockMvcResultMatchers.content().string("music successfully created id:" + music.getId())).toString();
+                        .andExpect(header().string("Location", matchesPattern("http://localhost:8080/music/\\d+"))).toString();
+
     }
 
     @Test
     @DataSet(value = "datasets/music.yml")
     @Transactional
     void ミュージックが更新されること() throws Exception {
-        Music music = new Music(1, "ハルカ", "YOASOBI");
         String response =
                 mockMvc.perform(MockMvcRequestBuilders.patch("/music/1")
                                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/example/homework10/integrationtest/MusicApiIntegrationTest.java
+++ b/src/test/java/com/example/homework10/integrationtest/MusicApiIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.example.homework10.integrationtest;
 
+
+import com.example.homework10.entity.Music;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
@@ -85,6 +87,7 @@ class MusicApiIntegrationTest {
     @DataSet(value = "datasets/music.yml")
     @Transactional
     void ミュージックが作成されること() throws Exception {
+        Music music = new Music(39, "ハルカ", "YOASOBI");
         String response =
                 mockMvc.perform(MockMvcRequestBuilders.post("/music")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -95,13 +98,61 @@ class MusicApiIntegrationTest {
                                         }
                                         """))
                         .andExpect(MockMvcResultMatchers.status().isCreated())
+                        .andExpect(MockMvcResultMatchers.content().string("music successfully created id:" + music.getId())).toString();
+    }
+
+    @Test
+    @DataSet(value = "datasets/music.yml")
+    @Transactional
+    void ミュージックが更新されること() throws Exception {
+        Music music = new Music(1, "ハルカ", "YOASOBI");
+        String response =
+                mockMvc.perform(MockMvcRequestBuilders.patch("/music/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "title": "アイドル",
+                                            "singer": "YOASOBI"
+                                        }
+                                        """))
+                        .andExpect(MockMvcResultMatchers.status().isOk())
                         .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         JSONAssert.assertEquals("""
                 {
-                    "id":4,
-                    "title":"ハルカ",
-                    "singer":"YOASOBI"
+                    "message": "music successfully updated"
+                }                   
+                """, response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/music.yml")
+    @Transactional
+    void 存在しないIDのミュージックを更新しようとすると404が返ること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.patch("/music/100")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "title": "アイドル",
+                                    "singer": "YOASOBI"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getErrorMessage();
+    }
+
+    @Test
+    @DataSet(value = "datasets/music.yml")
+    @Transactional
+    void ミュージックが削除されること() throws Exception {
+        String response =
+                mockMvc.perform(MockMvcRequestBuilders.delete("/music/1"))
+                        .andExpect(MockMvcResultMatchers.status().isOk())
+                        .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("""
+                {
+                    "message": "music successfully deleted"
                 }
                 """, response, JSONCompareMode.STRICT);
     }

--- a/src/test/java/com/example/homework10/mapper/MusicMapperTest.java
+++ b/src/test/java/com/example/homework10/mapper/MusicMapperTest.java
@@ -39,7 +39,7 @@ public class MusicMapperTest {
     @Test
     @Transactional
     void 指定したIDのミュージックが指定できる事() {
-        Music music = musicMapper.findById(5);
+        Optional<Music> music = musicMapper.findById(5);
         assertThat(music)
                 .isEqualTo(
                         new Music(5, "ハルカ", "YOASOBI")
@@ -50,7 +50,7 @@ public class MusicMapperTest {
     @Transactional
     void 指定したIDがない場合に例外を返す事() {
         int id = 100;
-        Music music = musicMapper.findById(id);
+        Optional<Music> music = musicMapper.findById(id);
         assertThat(music).isNull();
     }
 
@@ -59,7 +59,7 @@ public class MusicMapperTest {
     void ミュージックが作成される事() {
         Music music = new Music(8, "彗星の魔女", "YOASOBI");
         musicMapper.createMusic(music);
-        Optional<Music> actual = Optional.ofNullable(musicMapper.findById(music.getId()));
+        Optional<Music> actual = musicMapper.findById(music.getId());
         assertThat(actual).isPresent();
         assertThat(actual.get()).isEqualTo(music);
         assertThat(actual.get().getTitle()).isEqualTo(music.getTitle());
@@ -70,22 +70,18 @@ public class MusicMapperTest {
     @Test
     @Transactional
     void 更新したミュージックが反映されること() {
-        Optional<Music> music = Optional.ofNullable(musicMapper.findById(5));
+        Optional<Music> music = musicMapper.findById(5);
         assertThat(music).isEqualTo(Optional.of(new Music(5, "ハルカ", "YOASOBI")));
-        music.get().setTitle("炎");
-        music.get().setSinger("LiSA");
-        musicMapper.updateMusic(music.get());
-        Optional<Music> actual = Optional.ofNullable(musicMapper.findById(5));
-        assertThat(actual).isEqualTo(Optional.of(new Music(5, "炎", "LiSA")));
+        musicMapper.updateMusic(5, "ハルカ", "YOASOBI");
     }
 
     @Test
     @Transactional
     void 指定したIDのミュージックが削除されること() {
-        Optional<Music> music = Optional.ofNullable(musicMapper.findById(5));
+        Optional<Music> music = musicMapper.findById(5);
         assertThat(music).isEqualTo(Optional.of(new Music(5, "ハルカ", "YOASOBI")));
         musicMapper.deleteMusic(5);
-        Optional<Music> actual = Optional.ofNullable(musicMapper.findById(5));
+        Optional<Music> actual = musicMapper.findById(5);
         assertThat(actual).isEmpty();
     }
 }

--- a/src/test/java/com/example/homework10/service/MusicServiceImplTest.java
+++ b/src/test/java/com/example/homework10/service/MusicServiceImplTest.java
@@ -58,7 +58,7 @@ public class MusicServiceImplTest {
 
     @Test
     public void ミュージックが作成されること() {
-        Music music = new Music(5, "明日への扉", "kiroro");
+        Music music = new Music(0, "明日への扉", "kiroro");
         doNothing().when(musicMapper).createMusic(music);
 
         musicService.createMusic(music.getTitle(), music.getSinger());

--- a/src/test/java/com/example/homework10/service/MusicServiceImplTest.java
+++ b/src/test/java/com/example/homework10/service/MusicServiceImplTest.java
@@ -58,7 +58,7 @@ public class MusicServiceImplTest {
 
     @Test
     public void ミュージックが作成されること() {
-        Music music = new Music(0, "明日への扉", "kiroro");
+        Music music = new Music("明日への扉", "kiroro");
         doNothing().when(musicMapper).createMusic(music);
 
         musicService.createMusic(music.getTitle(), music.getSinger());

--- a/src/test/java/com/example/homework10/service/MusicServiceImplTest.java
+++ b/src/test/java/com/example/homework10/service/MusicServiceImplTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -63,25 +64,23 @@ public class MusicServiceImplTest {
 
         musicService.createMusic(music.getTitle(), music.getSinger());
         verify(musicMapper, times(1)).createMusic(music);
-
     }
 
     @Test
     public void 存在するミュージックが更新されること() throws Exception {
         Music music = new Music(5, "ハルカ", "YOASOBI");
-        doNothing().when(musicMapper).updateMusic(music);
+        doNothing().when(musicMapper).updateMusic(music.getId(), music.getTitle(), music.getSinger());
 
-        musicService.updateMusic(5, music);
-        verify(musicMapper, times(1)).updateMusic(music);
+        musicService.updateMusic(5, "ハルカ", "YOASOBI");
+        verify(musicMapper, times(1)).updateMusic(music.getId(), music.getTitle(), music.getSinger());
     }
 
     @Test
     public void 存在しないミュージックが更新されようとすると例外が発生すること() throws Exception {
-        Music music = new Music(5, "ハルカ", "YOASOBI");
-        doThrow(new NotMusicFoundException("Music not found")).when(musicMapper).updateMusic(music);
+        doReturn(Optional.empty()).when(musicMapper).findById(5);
 
-        assertThatThrownBy(() -> musicService.updateMusic(5, music)).isInstanceOfSatisfying(NotMusicFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("Music not found"));
-        verify(musicMapper, times(1)).updateMusic(music);
+        assertThatThrownBy(() -> musicService.updateMusic(5, "ハルカ", "YOASOBI")).isInstanceOfSatisfying(NotMusicFoundException.class, e -> assertThat(e.getMessage()).isEqualTo("Music not found"));
+        verify(musicMapper, times(1)).findById(5);
     }
 
     @Test

--- a/src/test/resources/datasets/expected_music.yml
+++ b/src/test/resources/datasets/expected_music.yml
@@ -1,0 +1,13 @@
+music:
+  - id: 1
+    title: "The Beginning"
+    singer: "ONE OK ROCK"
+  - id: 2
+    title: "Pretender"
+    singer: "Official髭男dism"
+  - id: 3
+    title: "Lemon"
+    singer: "米津玄師"
+  - id: 4
+    title: "ハルカ"
+    singer: "YOASOBI"


### PR DESCRIPTION
 結合テストのCREATE・PATCH・DELETEについて実装した。
CREATEに関してIDが作成するたびに自動で１ずつ増えてしまうため、期待値のID値をテストごとに1つずつ増やさないといけない仕様になってしまいました。
これではテストコードと言えるのか微妙だと感じています。
music.getIdなどでその値を取得しようとしましたがうまくいきませんでした。

レビューのほどよろしくお願い致します。